### PR TITLE
Refactor transfer_guest_user_actions_to_current_user to allow overrides

### DIFF
--- a/lib/commonwealth-vlr-engine/controller_override.rb
+++ b/lib/commonwealth-vlr-engine/controller_override.rb
@@ -294,18 +294,6 @@ module CommonwealthVlrEngine
     # When a user logs in, transfer any saved searches or bookmarks to the current_user
     def transfer_guest_user_actions_to_current_user
       return unless respond_to? :current_user and respond_to? :guest_user and current_user and guest_user
-      current_user_searches = current_user.searches.pluck(:query_params)
-      current_user_bookmarks = current_user.bookmarks.pluck(:document_id)
-
-      guest_user.searches.reject { |s| current_user_searches.include?(s.query_params)}.each do |s|
-        current_user.searches << s
-        s.save!
-      end
-
-      guest_user.bookmarks.reject { |b| current_user_bookmarks.include?(b.document_id)}.each do |b|
-        current_user.bookmarks << b
-        b.save!
-      end
 
       #Custom code to transfer over folders
       guest_user.folders.each do |folder|
@@ -324,8 +312,7 @@ module CommonwealthVlrEngine
         end
       end
 
-      # let guest_user know we've moved some bookmarks from under it
-      guest_user.reload if guest_user.persisted?
+      super
     end
 
   end


### PR DESCRIPTION
Moves duplicated blacklight functionality out of the `commonwealth-vlr-engine` version of `transfer_guest_user_actions_to_current_user`, instead relying on the blacklight superclass.

This also allows controllers which include this concern to also include their own versions of this method, which will be called instead of / in addition to the Blacklight version when `super` is called.

Before this change, controllers which included the `CommonwealthVlrEngine::Controller` (example given below) were unable to customize `transfer_guest_user_actions_to_current_user`, as the version defined in `CommonwealthVlrEngine` would be called first.