### PR TITLE
Fulltext search improvements

### DIFF
--- a/app/helpers/commonwealth_vlr_engine/ocr_search_helper_behavior.rb
+++ b/app/helpers/commonwealth_vlr_engine/ocr_search_helper_behavior.rb
@@ -34,17 +34,16 @@ module CommonwealthVlrEngine
     end
 
     # link to the book viewer, using page number or image index
-    # @document = SolrDocument (page object)
-    # @image_pid_list = an ordered Array of image pids for the book object
-    # @book_id = pid of book object
+    # @param document [SolrDocument] page object
+    # @param image_pid_list [Array] ordered Array of image pids for the book object
+    # @param book_id [String] ARK id of book object
     def render_page_link(document, image_pid_list, book_id)
       index_of_doc = image_pid_list.index(document.id)
       page_num = document[blacklight_config.page_num_field.to_sym]
-      # TODO: UV doesn't seem to allow passing query string, as in "h=#{url_encode(params[:ocr_q])}"
+      viewer_path = "#{book_viewer_path(book_id)}#?&cv=#{index_of_doc}"
+      viewer_path += "&h=#{url_encode(params[:ocr_q])}" if params[:ocr_q].present?
       link_to page_num ? "Page #{page_num}" : "Image #{index_of_doc + 1}",
-              "#{book_viewer_path(book_id)}#?&cv=#{index_of_doc}",
-              class: 'book_page_link',
-              rel: 'nofollow'
+              viewer_path, class: 'book_page_link', rel: 'nofollow'
     end
   end
 end

--- a/app/models/blacklight_iiif_search/iiif_search_annotation.rb
+++ b/app/models/blacklight_iiif_search/iiif_search_annotation.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# corresponds to IIIF Annotation resource
+module BlacklightIiifSearch
+  class IiifSearchAnnotation
+    include IIIF::Presentation
+    include BlacklightIiifSearch::AnnotationBehavior
+
+    attr_reader :document, :query, :hl_index, :snippet, :controller,
+                :parent_document, :hl_term_index
+
+    ##
+    # @param document [SolrDocument]
+    # @param query [String]
+    # @param hl_index [Integer]
+    # @param snippet [String]
+    # @param controller [CatalogController]
+    # @param parent_document [SolrDocument]
+    # @param hl_term_index [Integer] index of highlighted term within snippet
+    # rubocop:disable Metrics/ParameterLists
+    def initialize(document, query, hl_index, snippet, controller, parent_document, hl_term_index)
+      @document = document
+      @query = query
+      @hl_index = hl_index
+      @snippet = snippet
+      @controller = controller
+      @parent_document = parent_document
+      @hl_term_index = hl_term_index
+    end
+    # rubocop:enable Metrics/ParameterLists
+
+    ##
+    # @return [IIIF::Presentation::Annotation]
+    def as_hash
+      annotation = IIIF::Presentation::Annotation.new('@id' => annotation_id)
+      annotation.resource = text_resource_for_annotation if snippet
+      annotation['on'] = canvas_uri_for_annotation
+      annotation
+    end
+
+    ##
+    # @return [IIIF::Presentation::Resource]
+    def text_resource_for_annotation
+      clean_snippet = ActionView::Base.full_sanitizer.sanitize(snippet)
+      IIIF::Presentation::Resource.new('@type' => 'cnt:ContentAsText',
+                                       'chars' => clean_snippet)
+    end
+  end
+end

--- a/app/models/concerns/blacklight_iiif_search/annotation_behavior.rb
+++ b/app/models/concerns/blacklight_iiif_search/annotation_behavior.rb
@@ -23,12 +23,12 @@ module BlacklightIiifSearch
 
       coords_json = fetch_and_parse_coords
       if coords_json && coords_json['words']
-        matches = coords_json['words'].select { |k, _v| k.casecmp?(query) }
+        matches = coords_json['words'].select { |k, _v| k.gsub(/[\.,:;?!)]\z/, '') == query }
         return default unless matches
 
         # when multi-word query, hl_index may not exist for term, so use the highest index available
         term_coords_array = nil
-        hl_index.downto(0) do |h_i|
+        hl_term_index.downto(0) do |h_i|
           next if term_coords_array
 
           term_coords_array = matches.values.flatten(1)[h_i]

--- a/app/views/image_viewer/_uv_viewer.html.erb
+++ b/app/views/image_viewer/_uv_viewer.html.erb
@@ -35,6 +35,7 @@
               rangeId: urlDataProvider.get('rid', 0),
               rotation: Number(urlDataProvider.get('r', 0)),
               xywh: urlDataProvider.get('xywh', ''),
+              highlight: urlDataProvider.get('h', ''),
               embedded: true,
               locales: formattedLocales
           }, urlDataProvider);

--- a/lib/generators/commonwealth_vlr_engine/templates/public/uv/uv.html
+++ b/lib/generators/commonwealth_vlr_engine/templates/public/uv/uv.html
@@ -60,6 +60,7 @@
                 canvasIndex: Number(urlDataProvider.get('cv', 0)),
                 rotation: Number(urlDataProvider.get('r', 0)),
                 xywh: urlDataProvider.get('xywh', ''),
+                highlight: urlDataProvider.get('h', ''),
                 embedded: true,
                 locales: formattedLocales
             }, urlDataProvider);

--- a/spec/models/concerns/blacklight_iiif_search/annotation_behavior_spec.rb
+++ b/spec/models/concerns/blacklight_iiif_search/annotation_behavior_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe BlacklightIiifSearch::AnnotationBehavior do
   let(:iiif_search_annotation) do
     BlacklightIiifSearch::IiifSearchAnnotation.new(page_doc, query_term,
                                                    0, nil, controller,
-                                                   parent_doc)
+                                                   parent_doc, 0)
   end
   let(:test_request) { ActionDispatch::TestRequest.new({}) }
 


### PR DESCRIPTION
* pass query term to Universal Viewer from OCR search results
* support query/highlight parameter when initializing Universal Viewer
* improve handling of highlight matches when parsing `text_coordinates_access` attachment for coordinates