### PR TITLE
Google Analytics 4 updates

### DIFF
--- a/app/assets/stylesheets/commonwealth-vlr-engine/basic_search.scss
+++ b/app/assets/stylesheets/commonwealth-vlr-engine/basic_search.scss
@@ -1,6 +1,6 @@
 /* styles for basic search (catalog#index with no search params) */
 
-#basic_search_form {
+#basic_search_form_wrapper {
   margin-top:40px;
 
   #search_field {

--- a/app/assets/stylesheets/commonwealth-vlr-engine/collections.scss
+++ b/app/assets/stylesheets/commonwealth-vlr-engine/collections.scss
@@ -132,7 +132,7 @@ h4.collection-provenance {
     }
   }
 
-  #collection_search_form {
+  #collection_search_form_wrapper {
     padding: 0 3px 0 0;
 
     input {

--- a/app/assets/stylesheets/commonwealth-vlr-engine/institutions.scss
+++ b/app/assets/stylesheets/commonwealth-vlr-engine/institutions.scss
@@ -117,7 +117,7 @@ div.blacklight-institution {
 
     }
 
-    #institution_search_form {
+    #institution_search_form_wrapper {
 
       input {
         width: 255px;

--- a/app/views/catalog/_add_this.html.erb
+++ b/app/views/catalog/_add_this.html.erb
@@ -1,9 +1,0 @@
-<!-- AddThis Button BEGIN -->
-<div id="social_media_links" class="addthis_toolbox addthis_default_style addthis_32x32_style">
-  <a class="addthis_button_facebook" style="cursor:pointer"></a>
-  <a class="addthis_button_twitter" style="cursor:pointer"></a>
-  <a class="addthis_button_pinterest_share" style="cursor:pointer"></a>
-  <a class="addthis_button_compact"></a>
-</div>
-<script type="text/javascript" src="https://s7.addthis.com/js/300/addthis_widget.js#pubid=xa-505226a67a68dc99"></script>
-<!-- AddThis Button END -->

--- a/app/views/catalog/_basic_search.html.erb
+++ b/app/views/catalog/_basic_search.html.erb
@@ -16,7 +16,7 @@
     <div class="tab-pane active" id="basic_search">
       <div class="row">
         <div class="col-lg-8">
-          <div id="basic_search_form">
+          <div id="basic_search_form_wrapper">
             <%= render_search_bar %>
           </div>
         </div>

--- a/app/views/catalog/_previous_next_doc.html.erb
+++ b/app/views/catalog/_previous_next_doc.html.erb
@@ -13,7 +13,7 @@
       <% if current_search_session %>
         <div class="search-widgets">
           <%= render 'start_over' %>
-          <%= link_back_to_catalog id: 'startOverLink',
+          <%= link_back_to_catalog id: 'back_to_catalog_link',
                                    class: 'btn btn-sm btn-outline-secondary' %>
         </div>
       <% end %>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,5 +1,8 @@
+<%# rendered on home page and /search %>
 <%# override so we can use suggest_index_catalog_path for autocomplete_path %>
-<%= form_tag search_action_url, method: :get, class: 'search-query-form', role: 'search', 'aria-label' => t('blacklight.search.form.submit') do %>
+<%= form_tag search_action_url, method: :get, class: 'search-query-form', role: 'search',
+             id: "#{action_name == 'home' ? 'home-page' : 'basic'}-search-form",
+             'aria-label' => t('blacklight.search.form.submit') do %>
   <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
   <% if search_fields.length > 1 %>
     <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>

--- a/app/views/catalog/_sharing.html.erb
+++ b/app/views/catalog/_sharing.html.erb
@@ -1,0 +1,2 @@
+<%# placeholder for social sharing links (replaces deprecated AddThis widget) %>
+<!-- social sharing links TK -->

--- a/app/views/collections/_search_form_collection.html.erb
+++ b/app/views/collections/_search_form_collection.html.erb
@@ -1,6 +1,5 @@
-<div id="collection_search_form">
-  <%= form_tag search_action_url, method: :get,
-               class: 'search-query-form form-inline collection-search',
+<div id="collection_search_form_wrapper">
+  <%= form_tag search_action_url, method: :get, id: 'collection-search-form', class: 'search-query-form form-inline',
                role: 'search', 'aria-label' => t('blacklight.search.form.submit') do %>
     <%= render_hash_as_hidden_fields(search_state.params_for_search.except('q', 'search_field', 'qt', 'page')) %>
     <%= hidden_field_tag :search_field, blacklight_config.full_text_index %>

--- a/app/views/institutions/_search_form_institution.html.erb
+++ b/app/views/institutions/_search_form_institution.html.erb
@@ -1,6 +1,6 @@
-<div id="institution_search_form">
-  <%= form_tag search_action_url, method: :get,
-               class: 'search-query-form form-inline institution-search',
+<div id="institution_search_form_wrapper">
+  <%= form_tag search_action_url, method: :get, id: 'institution-search-form',
+               class: 'search-query-form form-inline',
                role: 'search', 'aria-label' => t('blacklight.search.form.submit') do %>
       <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page)) %>
 

--- a/app/views/ocr_search/_search_form_ocr.html.erb
+++ b/app/views/ocr_search/_search_form_ocr.html.erb
@@ -1,6 +1,6 @@
 <%# use blacklight_modal: 'preserve' once https://github.com/projectblacklight/blacklight/issues/2331 resolved %>
 <div id="ocr_search_form_wrapper">
-  <%= form_tag ocr_search_path, method: :get, class: 'ocr-search-form',
+  <%= form_tag ocr_search_path, method: :get, class: 'ocr-search-form', id: 'ocr-search-form',
                data: { blacklight_modal: 'trigger' } do %>
     <%= render_hash_as_hidden_fields(search_state.params_for_search(id: params[:id]).except('q', 'ocr_q',
                                                                                             'search_field', 'qt', 'page')) %>

--- a/app/views/shared/_search_form_header.html.erb
+++ b/app/views/shared/_search_form_header.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag search_action_url, method: :get, class: 'header-search-form form-inline',
+<%= form_tag search_action_url, method: :get, class: 'form-inline', id: 'header-search-form',
              'aria-label' => t('blacklight.search.form.submit') do %>
     <%= render_hash_as_hidden_fields(search_state.params_for_search(search_field: default_search_field[:key]).except('q', 'qt', 'page', 'utf8', 'f', 'sort', 'mlt_id', 'coordinates', 'spatial_search_type', 'view', 'range', 'date_start', 'date_end')) %>
 

--- a/lib/commonwealth-vlr-engine/controller_override.rb
+++ b/lib/commonwealth-vlr-engine/controller_override.rb
@@ -207,7 +207,7 @@ module CommonwealthVlrEngine
         config.add_sort_field 'date_start_dtsi desc, title_info_primary_ssort asc', label: 'date (desc)'
 
         # add our custom tools
-        config.add_show_tools_partial :add_this, partial: 'add_this', if: :render_add_this?
+        config.add_show_tools_partial :sharing, partial: 'sharing', if: :render_sharing?
       end
 
       # displays the MODS XML record. copied from blacklight-marc 'librarian_view'
@@ -249,14 +249,14 @@ module CommonwealthVlrEngine
       blacklight_config.facet_fields['genre_basic_ssim'].collapse = true
       blacklight_config.facet_fields['reuse_allowed_ssi'].collapse = true
       # remove item-centric show tools (for admin)
-      blacklight_config.show.document_actions.delete(:add_this)
+      blacklight_config.show.document_actions.delete(:sharing)
       blacklight_config.show.document_actions.delete(:bookmark)
       blacklight_config.show.document_actions.delete(:email)
       blacklight_config.show.document_actions.delete(:citation)
     end
 
-    # display the AddThis social/sharing widget in catalog#show
-    def render_add_this?
+    # display the social/sharing widget in catalog#show
+    def render_sharing?
       true
     end
 

--- a/spec/features/catalog/_basic_search_spec.rb
+++ b/spec/features/catalog/_basic_search_spec.rb
@@ -8,7 +8,7 @@ describe 'basic_search', js: true do
   end
 
   it 'shows correct results after running a fielded search' do
-    within '#basic_search_form' do
+    within '#basic_search_form_wrapper' do
       select('Title', from: 'search_field')
       fill_in 'q', with: 'parking'
       click_button('search')
@@ -19,7 +19,7 @@ describe 'basic_search', js: true do
   end
 
   it 'shows correct results after running a full-text search' do
-    within '#basic_search_form' do
+    within '#basic_search_form_wrapper' do
       find('#fulltext_checkbox').click
       fill_in 'q', with: 'assistance'
       click_button('search')
@@ -30,7 +30,7 @@ describe 'basic_search', js: true do
   end
 
   it 'unchecks the full-text checkbox when a non-full-text index is selected' do
-    within '#basic_search_form' do
+    within '#basic_search_form_wrapper' do
       find('#fulltext_checkbox').click
       select('Title', from: 'search_field')
       expect(page).to_not have_checked_field('fulltext_checkbox')

--- a/spec/lib/commonwealth-vlr-engine/controller_override_spec.rb
+++ b/spec/lib/commonwealth-vlr-engine/controller_override_spec.rb
@@ -77,14 +77,14 @@ describe CommonwealthVlrEngine::ControllerOverride do
       subject { test_config.show.document_actions }
 
       it 'adds the desired actions' do
-        expect(subject[:add_this]).not_to be_empty
+        expect(subject[:sharing]).not_to be_empty
       end
     end
   end
 
-  describe '#render_add_this?' do
+  describe '#render_sharing?' do
     it 'returns the correct boolean value' do
-      expect(mock_controller.send(:render_add_this?)).to be_truthy
+      expect(mock_controller.send(:render_sharing?)).to be_truthy
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,15 +34,6 @@ end
 Billy.configure do |c|
   c.cache = true
   c.cache_request_headers = false
-  # for AddThis social/sharing widget: app/views/catalog/_add_this.html.erb
-  c.ignore_params = %w(
-    https://s7.addthis.com/js/300/addthis_widget.js
-    https://m.addthis.com/live/red_lojson/300lo.json
-    https://s7.addthis.com/static/sh.f48a1a04fe8dbf021b4cda1d.html
-    https://v1.addthisedge.com/live/boost/xa-505226a67a68dc99/_ate.track.config_resp
-    https://z.moatads.com/addthismoatframe568911941483/moatframe.js
-    https://m.addthis.com/live/red_lojson/100eng.json
-  )
   c.path_blacklist = []
   c.merge_cached_responses_whitelist = []
   c.persist_cache = true


### PR DESCRIPTION
* minor modifications to code to facilitate tracking with Google Analytics 4 and Google Tag Manager
* remove deprecated AddThis social sharing widget, replace with generic `sharing` partial to be updated at a later date